### PR TITLE
Fix house elevation state tracking across timesteps

### DIFF
--- a/docs/tutorial/03-adding-time.qmd
+++ b/docs/tutorial/03-adding-time.qmd
@@ -130,12 +130,12 @@ end
 
 ### State: What Evolves
 
-The **State** tracks variables that change over time. For this simple model, we don't need evolving state, but we still define it:
+The **State** tracks variables that change over time. For house elevation, the state tracks the current elevation of the house—it starts at zero and gets modified when we apply the policy:
 
 ```{julia}
 #| output: false
 struct HouseState{T<:AbstractFloat} <: AbstractState
-    placeholder::T  # Could track sea level rise, cumulative damage, etc.
+    elevation_ft::T
 end
 ```
 
@@ -165,12 +165,14 @@ With types defined, we implement five functions that tell the framework how to r
 
 ### 1. `initialize`: Create Starting State
 
+The house starts at ground level (no elevation):
+
 ```{julia}
 #| output: false
 function SimOptDecisions.initialize(
     ::HouseConfig, ::HouseScenario, ::AbstractRNG
 )
-    HouseState(0.0)
+    HouseState(0.0)  # House starts with no elevation
 end
 ```
 
@@ -196,7 +198,7 @@ end
 
 ### 4. `run_timestep`: Execute One Year
 
-This is where our physics from the previous section lives. Notice that we **read** the water level from the scenario—no sampling needed:
+This is where our physics from the previous section lives. The state tracks the house elevation, which gets modified by the action in the first timestep:
 
 ```{julia}
 #| output: false
@@ -208,21 +210,27 @@ function SimOptDecisions.run_timestep(
     scenario::HouseScenario,
     rng::AbstractRNG,
 )
-    # Construction cost only in year 1
-    construction_cost = is_first(t) ?
-        elevation_cost(action.elevation_ft, config.house_area_ft2, config.house_value) : 0.0
+    # Apply elevation in year 1, then state persists
+    if is_first(t)
+        new_elevation = state.elevation_ft + action.elevation_ft
+        construction_cost = elevation_cost(action.elevation_ft, config.house_area_ft2, config.house_value)
+    else
+        new_elevation = state.elevation_ft
+        construction_cost = 0.0
+    end
 
     # Get water level from scenario (pre-generated)
     water_level = scenario.water_levels[t]
 
-    # Compute flood depth and damage
-    floor_level = config.house_height + action.elevation_ft
+    # Compute flood depth and damage using current elevation
+    floor_level = config.house_height + new_elevation
     flood_depth = water_level - floor_level
     damage = depth_damage(flood_depth, value(scenario.dd_threshold), value(scenario.dd_saturation))
 
-    # Return new state and step record
+    # Return updated state and step record
+    new_state = HouseState(new_elevation)
     step_record = (construction_cost=construction_cost, damage_fraction=damage)
-    return (state, step_record)
+    return (new_state, step_record)
 end
 ```
 

--- a/docs/tutorial/04-outcomes-metrics.qmd
+++ b/docs/tutorial/04-outcomes-metrics.qmd
@@ -78,7 +78,7 @@ function sample_scenario(rng::AbstractRNG, horizon::Int)
 end
 
 struct HouseState{T<:AbstractFloat} <: AbstractState
-    placeholder::T
+    elevation_ft::T
 end
 
 struct ElevationAction{T<:AbstractFloat} <: AbstractAction
@@ -98,13 +98,18 @@ function SimOptDecisions.run_timestep(
     state::HouseState, action::ElevationAction, t::TimeStep,
     config::HouseConfig, scenario::HouseScenario, rng::AbstractRNG
 )
-    construction_cost = is_first(t) ?
-        elevation_cost(action.elevation_ft, config.house_area_ft2, config.house_value) : 0.0
+    if is_first(t)
+        new_elevation = state.elevation_ft + action.elevation_ft
+        construction_cost = elevation_cost(action.elevation_ft, config.house_area_ft2, config.house_value)
+    else
+        new_elevation = state.elevation_ft
+        construction_cost = 0.0
+    end
     water_level = scenario.water_levels[t]
-    floor_level = config.house_height + action.elevation_ft
+    floor_level = config.house_height + new_elevation
     flood_depth = water_level - floor_level
     damage = depth_damage(flood_depth, value(scenario.dd_threshold), value(scenario.dd_saturation))
-    return (state, (construction_cost=construction_cost, damage_fraction=damage))
+    return (HouseState(new_elevation), (construction_cost=construction_cost, damage_fraction=damage))
 end
 
 function SimOptDecisions.compute_outcome(

--- a/docs/tutorial/05-exploratory-modeling.qmd
+++ b/docs/tutorial/05-exploratory-modeling.qmd
@@ -81,7 +81,7 @@ function sample_scenario(rng::AbstractRNG, horizon::Int)
 end
 
 struct HouseState{T<:AbstractFloat} <: AbstractState
-    placeholder::T
+    elevation_ft::T
 end
 
 struct ElevationAction{T<:AbstractFloat} <: AbstractAction
@@ -101,16 +101,20 @@ function SimOptDecisions.run_timestep(
     state::HouseState, action::ElevationAction, t::TimeStep,
     config::HouseConfig, scenario::HouseScenario, rng::AbstractRNG
 )
-    construction_cost = is_first(t) ?
-        elevation_cost(action.elevation_ft, config.house_area_ft2, config.house_value) : 0.0
+    if is_first(t)
+        new_elevation = state.elevation_ft + action.elevation_ft
+        construction_cost = elevation_cost(action.elevation_ft, config.house_area_ft2, config.house_value)
+    else
+        new_elevation = state.elevation_ft
+        construction_cost = 0.0
+    end
 
-    # Get water level from scenario (pre-generated)
     water_level = scenario.water_levels[t]
-    floor_level = config.house_height + action.elevation_ft
+    floor_level = config.house_height + new_elevation
     flood_depth = water_level - floor_level
     damage = depth_damage(flood_depth, value(scenario.dd_threshold), value(scenario.dd_saturation))
 
-    return (state, (construction_cost=construction_cost, damage_fraction=damage))
+    return (HouseState(new_elevation), (construction_cost=construction_cost, damage_fraction=damage))
 end
 
 # Outcome with parameter wrappers (required for explore)

--- a/docs/tutorial/06-policy-search.qmd
+++ b/docs/tutorial/06-policy-search.qmd
@@ -56,7 +56,7 @@ function sample_scenario(rng::AbstractRNG, horizon::Int)
 end
 
 struct HouseState{T<:AbstractFloat} <: AbstractState
-    placeholder::T
+    elevation_ft::T
 end
 
 struct ElevationAction{T<:AbstractFloat} <: AbstractAction
@@ -116,16 +116,20 @@ function SimOptDecisions.run_timestep(
     state::HouseState, action::ElevationAction, t::TimeStep,
     config::HouseConfig, scenario::HouseScenario, rng::AbstractRNG
 )
-    construction_cost = is_first(t) ?
-        elevation_cost(action.elevation_ft, config.house_area_ft2, config.house_value) : 0.0
+    if is_first(t)
+        new_elevation = state.elevation_ft + action.elevation_ft
+        construction_cost = elevation_cost(action.elevation_ft, config.house_area_ft2, config.house_value)
+    else
+        new_elevation = state.elevation_ft
+        construction_cost = 0.0
+    end
 
-    # Get water level from scenario (pre-generated)
     water_level = scenario.water_levels[t]
-    floor_level = config.house_height + action.elevation_ft
+    floor_level = config.house_height + new_elevation
     flood_depth = water_level - floor_level
     damage = depth_damage(flood_depth, value(scenario.dd_threshold), value(scenario.dd_saturation))
 
-    return (state, (construction_cost=construction_cost, damage_fraction=damage))
+    return (HouseState(new_elevation), (construction_cost=construction_cost, damage_fraction=damage))
 end
 
 function SimOptDecisions.compute_outcome(


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in the house elevation model where the state was not properly tracking elevation changes across timesteps. Previously, the elevation action was applied in the first timestep but not persisted in the state, causing incorrect floor level calculations in subsequent years.

## Key Changes
- **State representation**: Renamed `HouseState.placeholder` to `HouseState.elevation_ft` to clearly indicate it tracks the house's current elevation
- **State persistence**: Modified `run_timestep` to properly update and return the new state with accumulated elevation:
  - In the first timestep, elevation is applied and added to the state
  - In subsequent timesteps, the elevation persists (state is carried forward unchanged)
  - The returned state now correctly reflects the cumulative elevation
- **Physics calculation**: Updated floor level calculation to use `new_elevation` (the current state elevation) instead of just the action elevation
- **Documentation**: Enhanced comments to clarify that state tracks elevation and explain the initialization and update logic

## Implementation Details
The fix ensures that:
1. Elevation decisions made in year 1 are permanently stored in the state
2. Flood damage calculations in all subsequent years use the correct floor level based on the accumulated elevation
3. The state object returned from each timestep properly reflects the house's current condition
4. All tutorial files (03-adding-time, 04-outcomes-metrics, 05-exploratory-modeling, 06-policy-search) are updated consistently

This change makes the model physically accurate and ensures decisions have lasting effects throughout the simulation horizon.